### PR TITLE
cmd: Enable codeowners via -code-owners-prefix

### DIFF
--- a/cmd/go-junit-report/main.go
+++ b/cmd/go-junit-report/main.go
@@ -107,15 +107,9 @@ func main() {
 	hostname, _ := os.Hostname() // ignore error
 
 	var owners *codeowners.Ruleset
-	if logOwners != nil {
-		var ignorePrefix string
-
-		if logOwnersPrefix != nil {
-			ignorePrefix = *logOwnersPrefix
-		}
-
+	if *logOwnersPrefix != "" {
 		paths := strings.Split(*logOwners, ",")
-		o, err := codeowners.Load(paths, ignorePrefix)
+		o, err := codeowners.Load(paths, *logOwnersPrefix)
 		if err != nil {
 			exitf("error parsing owners file: %v", err)
 		}


### PR DESCRIPTION
Previously if this tool was run without any code owners flags, it would
immediately fail. This is not ideal for users who might not need to
include code owners information.

At the same time, in order for the code owners lookup to work, we need
to be able to remove the Go module prefix / repository before performing
the lookup in the code owners file.

It's nice to not have to specify -code-owners filepaths if you're just
using the standard locations.

This commit converges a solution for all of the above by only enabling
the code-owners functionality if the user specifies -code-owners-prefix.
